### PR TITLE
Routing buckets

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -42,6 +42,8 @@ AddEventHandler('apartments:server:OpenDoor', function(target, apartmentId, apar
     local src = source
     local OtherPlayer = QBCore.Functions.GetPlayer(target)
     if OtherPlayer ~= nil then
+        local bucket = GetPlayerRoutingBucket(src)
+        SetPlayerRoutingBucket(OtherPlayer, bucket)
         TriggerClientEvent('apartments:client:SpawnInApartment', OtherPlayer.PlayerData.source, apartmentId, apartment)
     end
 end)


### PR DESCRIPTION
Players are now inside their buckets.
So they can't see each other inside the apartment, until the player is invited inside.