### PR TITLE
Update apartment label in db on apartment change

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -110,7 +110,9 @@ Citizen.CreateThread(function()
                     if entrance < 1.2 then
                         QBCore.Functions.DrawText3D(Apartments.Locations[ClosestHouse].coords.enter.x, Apartments.Locations[ClosestHouse].coords.enter.y, Apartments.Locations[ClosestHouse].coords.enter.z, '~g~E~w~ - Change Apartment')
                         if IsControlJustPressed(0, 38) then -- E
-                            TriggerServerEvent("apartments:server:UpdateApartment", ClosestHouse)
+                            local apartmentType = ClosestHouse
+                            local apartmentLabel = Apartments.Locations[ClosestHouse].label
+                            TriggerServerEvent("apartments:server:UpdateApartment", apartmentType, apartmentLabel)
                             IsOwned = true
                         end
                     end

--- a/server/main.lua
+++ b/server/main.lua
@@ -19,10 +19,10 @@ AddEventHandler('apartments:server:CreateApartment', function(type, label)
 end)
 
 RegisterServerEvent('apartments:server:UpdateApartment')
-AddEventHandler('apartments:server:UpdateApartment', function(type)
+AddEventHandler('apartments:server:UpdateApartment', function(type, label)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-    exports.oxmysql:execute('UPDATE apartments SET type = ? WHERE citizenid = ?', { type, Player.PlayerData.citizenid })
+    exports.oxmysql:execute('UPDATE apartments SET type = ?, label = ? WHERE citizenid = ?', { type, label, Player.PlayerData.citizenid })
     TriggerClientEvent('QBCore:Notify', src, "You have changed apartments")
     TriggerClientEvent("apartments:client:SetHomeBlip", src, type)
 end)


### PR DESCRIPTION
The label of the apartments was not updating in the DB, so I added it.

Tested on a new install of QBCore and it worked without problems.