### PR TITLE
Fix Update Apartment

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -22,7 +22,9 @@ RegisterServerEvent('apartments:server:UpdateApartment')
 AddEventHandler('apartments:server:UpdateApartment', function(type, label)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-    exports.oxmysql:execute('UPDATE apartments SET type = ?, label = ? WHERE citizenid = ?', { type, label, Player.PlayerData.citizenid })
+    local appId = GetOwnedApartment(Player.PlayerData.citizenid).name:sub(11)
+    local newLabel = label .. " " .. appId
+    exports.oxmysql:execute('UPDATE apartments SET type = ?, label = ? WHERE citizenid = ?', { type, newLabel, Player.PlayerData.citizenid })
     TriggerClientEvent('QBCore:Notify', src, "You have changed apartments")
     TriggerClientEvent("apartments:client:SetHomeBlip", src, type)
 end)


### PR DESCRIPTION
This script currently only updates the label of the apt. from the config however does not pass the id through, thus is an apartment gets updated in the db it would just be "Integrity Way" instead of "Integrity Way 9032", which would break the doorbell script as the menu would just show a bunch of apartments labels if users changed apartments. Passing the label through is questionable as you can get it from the type but not the focus of this fix.
NOTE: this only works with 9 or less apartments in the config as it is currently ripping the id from the apartment29032 id in the db, ideally the id of the apartment would be stored individually in the database to future proof this.