### PR TITLE
Fix Update Apartment

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -74,7 +74,9 @@ end)
 RegisterNetEvent('apartments:server:UpdateApartment', function(type, label)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-    exports.oxmysql:execute('UPDATE apartments SET type = ?, label = ? WHERE citizenid = ?', { type, label, Player.PlayerData.citizenid })
+    local appId = GetOwnedApartment(Player.PlayerData.citizenid).name:sub(11)
+    local newLabel = label .. " " .. appId
+    exports.oxmysql:execute('UPDATE apartments SET type = ?, label = ? WHERE citizenid = ?', { type, newLabel, Player.PlayerData.citizenid })
     TriggerClientEvent('QBCore:Notify', src, "You have changed apartments")
     TriggerClientEvent("apartments:client:SetHomeBlip", src, type)
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -73,12 +73,18 @@ end)
 
 RegisterNetEvent('apartments:server:UpdateApartment', function(type, label)
     local src = source
-    local Player = QBCore.Functions.GetPlayer(src)
-    local appId = GetOwnedApartment(Player.PlayerData.citizenid).name:sub(11)
-    local newLabel = label .. " " .. appId
-    exports.oxmysql:execute('UPDATE apartments SET type = ?, label = ? WHERE citizenid = ?', { type, newLabel, Player.PlayerData.citizenid })
-    TriggerClientEvent('QBCore:Notify', src, "You have changed apartments")
-    TriggerClientEvent("apartments:client:SetHomeBlip", src, type)
+    local cid = QBCore.Functions.GetPlayer(src).PlayerData.citizenid
+    QBCore.Functions.TriggerCallback('apartments:GetOwnedApartment', source,  function(result)
+        if result then
+    	    local appId = result.name:sub(#result.type + 1)
+    	    local newLabel = label .. " " .. appId
+   	        exports.oxmysql:execute('UPDATE apartments SET type = ?, label = ? WHERE citizenid = ?', { type, newLabel, cid })
+    	    TriggerClientEvent('QBCore:Notify', src, "You have changed apartments")
+    	    TriggerClientEvent("apartments:client:SetHomeBlip", src, type)
+        else
+            TriggerClientEvent('QBCore:Notify', source, "There was an error changing your apartment", "error")				
+        end
+    end, cid)
 end)
 
 RegisterNetEvent('apartments:server:RingDoor', function(apartmentId, apartment)


### PR DESCRIPTION
This script currently only updates the label of the apt. from the config however does not pass the id through, thus is an apartment gets updated in the db it would just be "Integrity Way" instead of "Integrity Way 9032". 
NOTE: this only works with 9 or less apartments in the config as it is currently ripping the id from the apartment29032 id in the db, ideally the id of the apartment would be stored individually in the database to future proof this.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [i believe so ]
