### PR TITLE
PZ integration follow up to fix issues and remove qb-target

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -96,6 +96,10 @@ local function RegisterApartmentEntranceZone(apartmentID, apartmentData)
   local boxName = 'apartmentEntrance_' .. apartmentID
   local boxData = apartmentData.polyzoneBoxData
 
+  if  boxData.created then
+      return
+  end
+
   local zone =
     BoxZone:Create(
     coords,

--- a/config.lua
+++ b/config.lua
@@ -2,10 +2,6 @@ Apartments = {}
 Apartments.Starting = true
 Apartments.SpawnOffset = 30
 
--- **** IMPORTANT ****
--- UseTarget should only be set to true when using qb-target
-Apartments.UseTarget = GetConvar('UseTarget', 'false') == 'true'
-
 Apartments.Locations = {
     ["apartment1"] = {
         name = "apartment1",

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'QB-Apartments'
-version '2.0.0'
+version '2.1.0'
 
 shared_scripts {
     'config.lua',


### PR DESCRIPTION
This PR removes the previously added qb-target integration as it does not fit in this resource. The new version will open a menu when the player is in the target position for the entrance and exit apartment coords.