### PR TITLE
[QOL] Pull useStartingApartments config option from qb-multicharacter

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -440,14 +440,14 @@ RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
     DeleteInApartmentTargets()
 end)
 
-RegisterNetEvent('apartments:client:setupSpawnUI', function(cData)
+RegisterNetEvent('apartments:client:setupSpawnUI', function(cData, startingApartments)
     QBCore.Functions.TriggerCallback('apartments:GetOwnedApartment', function(result)
         if result then
             TriggerEvent('qb-spawn:client:setupSpawns', cData, false, nil)
             TriggerEvent('qb-spawn:client:openUI', true)
             TriggerEvent("apartments:client:SetHomeBlip", result.type)
         else
-            if Apartments.Starting then
+            if startingApartments then
                 TriggerEvent('qb-spawn:client:setupSpawns', cData, true, Apartments.Locations)
                 TriggerEvent('qb-spawn:client:openUI', true)
             else

--- a/client/main.lua
+++ b/client/main.lua
@@ -440,14 +440,14 @@ RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
     DeleteInApartmentTargets()
 end)
 
-RegisterNetEvent('apartments:client:setupSpawnUI', function(cData, startingApartments)
+RegisterNetEvent('apartments:client:setupSpawnUI', function(cData, useStartingApartments)
     QBCore.Functions.TriggerCallback('apartments:GetOwnedApartment', function(result)
         if result then
             TriggerEvent('qb-spawn:client:setupSpawns', cData, false, nil)
             TriggerEvent('qb-spawn:client:openUI', true)
             TriggerEvent("apartments:client:SetHomeBlip", result.type)
         else
-            if startingApartments then
+            if useStartingApartments then
                 TriggerEvent('qb-spawn:client:setupSpawns', cData, true, Apartments.Locations)
                 TriggerEvent('qb-spawn:client:openUI', true)
             else

--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,4 @@
 Apartments = {}
-Apartments.Starting = true
 Apartments.SpawnOffset = 30
 Apartments.Locations = {
     ["apartment1"] = {


### PR DESCRIPTION
**Describe Pull request**
Currently, if a user wishes to setup their server to not use the starting apartments, they have to change a config option in both qb-apartments and qb-multicharacter. This PR acts to streamline that process by making the qb-multicharacter option control the logic within qb-apartments.

qb-multicharacter now passes its config option as an argument to the `setupSpawnUI` event in qb-apartments.

Linked to https://github.com/qbcore-framework/qb-multicharacter/pull/130

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
