### PR TITLE
Fix for Warning: Could not find file

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -18,7 +18,6 @@ server_scripts {
 
 client_scripts {
     'client/main.lua',
-    'client/gui.lua',
     '@PolyZone/client.lua',
     '@PolyZone/BoxZone.lua',
     '@PolyZone/CircleZone.lua',


### PR DESCRIPTION
This fixes the console warning being thrown when starting the script.