### PR TITLE
Increased possible amount of apartment id's

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -8,7 +8,7 @@ local function CreateApartmentId(type)
     local AparmentId = nil
 
     while not UniqueFound do
-        AparmentId = tostring(math.random(1, 9999))
+        AparmentId = tostring(math.random(1, 1000000))
         local result = MySQL.query.await('SELECT COUNT(*) as count FROM apartments WHERE name = ?', { tostring(type .. AparmentId) })
         if result[1].count == 0 then
             UniqueFound = true


### PR DESCRIPTION
**Describe Pull request**
Increase apartmentId generation from 1-9999 to 1-1000000 (1mil)

If your PR is to fix an issue mention that issue here
If over 10000 unique characters are created players are stuck in a loading screen since there are only 10 000 possible apartment ids therefore no new apartments can be made after that.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
